### PR TITLE
Add dynamic base preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,51 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: BASE=/pr-${{ github.event.pull_request.number }}/ npm run build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          publish_branch: gh-pages
+          destination_dir: pr-${{ github.event.pull_request.number }}
+          keep_files: true
+          clean: true
+      - name: Comment PR with preview URL
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Preview URL: https://weiqi-kids.github.io/elyndra.world/pr-${{ github.event.pull_request.number }}/

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: process.env.BASE || '/',
+});


### PR DESCRIPTION
## Summary
- update PR preview workflow to use pull_request.number safely
- deploy via `peaceiris/actions-gh-pages@v4` with automatic cleaning
- build Vite site with dynamic `BASE` env var
- add `vite.config.js` to read `process.env.BASE`

## Testing
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6853ad4593f08326b7c3d55abe3934fe