### PR TITLE
Add Magic Campus chat UI skeleton

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Magic Campus Chat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "elyndra.world",
+  "version": "1.0.0",
+  "description": "",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+  ,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "shadcn-ui": "^0.3.0",
+    "lucide-react": "^0.263.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Sidebar from '@/components/Sidebar';
+import ChatList from '@/components/ChatList';
+import ChatContent from '@/components/ChatContent';
+
+const App: React.FC = () => {
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar />
+      <div className="flex flex-1 overflow-hidden">
+        <ChatList />
+        <ChatContent />
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/ChatContent.tsx
+++ b/src/components/ChatContent.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef } from 'react';
+import MessageBubble, { Message } from './MessageBubble';
+import MessageInput from './MessageInput';
+import { Input } from "@/components/ui/input";
+import { Search } from 'lucide-react';
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+const mockMessages: Message[] = [
+  {
+    id: 1,
+    content: 'Hi there! Welcome to the Magic Campus.',
+    time: '09:00',
+    sender: 'Professor Oak',
+    avatar: 'https://placekitten.com/50/50',
+  },
+  {
+    id: 2,
+    content: 'Thank you professor!',
+    time: '09:02',
+    sender: 'You',
+    avatar: 'https://placekitten.com/52/52',
+    self: true,
+    readBy: 3,
+  },
+];
+
+const ChatContent: React.FC = () => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, []);
+
+  return (
+    <div className="flex-1 flex flex-col h-full">
+      <div className="p-2 border-b">
+        <div className="relative">
+          <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Search messages" className="pl-8" />
+        </div>
+      </div>
+      <ScrollArea ref={scrollRef} className="flex-1 p-4 space-y-4 overflow-y-auto">
+        {mockMessages.map((msg) => (
+          <MessageBubble key={msg.id} message={msg} />
+        ))}
+      </ScrollArea>
+      <MessageInput />
+    </div>
+  );
+};
+
+export default ChatContent;

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Search } from 'lucide-react';
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+export interface Conversation {
+  id: number;
+  title: string;
+  lastMessage: string;
+  time: string;
+  unread: number;
+  avatar: string;
+}
+
+const mockConversations: Conversation[] = [
+  {
+    id: 1,
+    title: 'Magic Club',
+    lastMessage: 'Hey everyone, meeting today at 5PM in the main hall.',
+    time: '10:24',
+    unread: 3,
+    avatar: 'https://placekitten.com/40/40',
+  },
+  {
+    id: 2,
+    title: 'Professor Oak',
+    lastMessage: 'Please submit your assignments before Friday. Long message example to show truncation in the list.',
+    time: '09:10',
+    unread: 0,
+    avatar: 'https://placekitten.com/41/41',
+  },
+];
+
+const ChatList: React.FC = () => {
+  return (
+    <div className="w-72 border-r h-full flex flex-col">
+      <div className="p-2">
+        <div className="relative">
+          <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Search" className="pl-8" />
+        </div>
+      </div>
+      <ScrollArea className="flex-1">
+        <div className="p-2 space-y-2">
+          {mockConversations.map((conv) => (
+            <Card key={conv.id} className="p-2 flex items-start space-x-2">
+              <Avatar>
+                <AvatarImage src={conv.avatar} />
+                <AvatarFallback>{conv.title[0]}</AvatarFallback>
+              </Avatar>
+              <div className="flex-1 min-w-0">
+                <div className="flex justify-between">
+                  <span className="font-medium truncate">{conv.title}</span>
+                  <span className="text-xs text-gray-500">{conv.time}</span>
+                </div>
+                <div className="flex justify-between items-center">
+                  <p className="text-sm text-gray-600 line-clamp-2 flex-1">
+                    {conv.lastMessage}
+                  </p>
+                  {conv.unread > 0 && (
+                    <Badge variant="default" className="ml-2 h-5 min-w-[20px] justify-center">
+                      {conv.unread}
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+};
+
+export default ChatList;

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card } from "@/components/ui/card";
+
+export interface Message {
+  id: number;
+  content: string;
+  time: string;
+  sender: string;
+  avatar: string;
+  self?: boolean;
+  readBy?: number;
+}
+
+interface Props {
+  message: Message;
+}
+
+const MessageBubble: React.FC<Props> = ({ message }) => {
+  return (
+    <div
+      className={`flex items-end space-x-2 ${message.self ? 'justify-end' : ''}`}
+    >
+      {!message.self && (
+        <Avatar className="h-8 w-8">
+          <AvatarImage src={message.avatar} />
+          <AvatarFallback>{message.sender[0]}</AvatarFallback>
+        </Avatar>
+      )}
+      <div className={`${message.self ? 'items-end' : ''} flex flex-col max-w-md`}>
+        {message.sender && !message.self && (
+          <span className="text-xs text-gray-500">{message.sender}</span>
+        )}
+        <Card className="p-2 bg-muted">
+          <p>{message.content}</p>
+        </Card>
+        <div className="text-xs text-gray-400 self-end flex space-x-1">
+          <span>{message.time}</span>
+          {typeof message.readBy === 'number' && (
+            <span className="ml-1">✓ {message.readBy}</span>
+          )}
+        </div>
+      </div>
+      {message.self && (
+        <Avatar className="h-8 w-8">
+          <AvatarImage src={message.avatar} />
+          <AvatarFallback>{message.sender[0]}</AvatarFallback>
+        </Avatar>
+      )}
+    </div>
+  );
+};
+
+export default MessageBubble;

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Smile, Image as ImageIcon, Send } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+const MessageInput: React.FC = () => {
+  return (
+    <div className="border-t p-2 flex items-end space-x-2">
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="ghost" size="icon">
+            <Smile className="h-5 w-5" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-40">Emoji picker</PopoverContent>
+      </Popover>
+      <Button variant="ghost" size="icon">
+        <ImageIcon className="h-5 w-5" />
+      </Button>
+      <Textarea
+        className="flex-1 resize-none" placeholder="Type a message" rows={1}
+      />
+      <Button variant="default" size="icon">
+        <Send className="h-5 w-5" />
+      </Button>
+    </div>
+  );
+};
+
+export default MessageInput;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Menu, X, User, Megaphone, MessageSquare, PlusSquare, SwitchCamera } from 'lucide-react';
+import { Button } from "@/components/ui/button";
+import { Drawer, DrawerContent, DrawerTrigger } from "@/components/ui/drawer";
+
+const items = [
+  { label: 'About Me', icon: User },
+  { label: 'Campus Announcements', icon: Megaphone },
+  { label: 'Chats', icon: MessageSquare, active: true },
+  { label: 'Create Group', icon: PlusSquare },
+  { label: 'Switch Role', icon: SwitchCamera },
+];
+
+const SidebarContent: React.FC = () => (
+  <div className="flex flex-col w-56 h-full bg-gray-100 p-4 space-y-2">
+    {items.map((item) => (
+      <Button
+        key={item.label}
+        variant={item.active ? 'secondary' : 'ghost'}
+        className="justify-start"
+      >
+        <item.icon className="mr-2 h-4 w-4" />
+        {item.label}
+      </Button>
+    ))}
+  </div>
+);
+
+const Sidebar: React.FC = () => {
+  return (
+    <>
+      <div className="hidden md:block h-full">
+        <SidebarContent />
+      </div>
+      <div className="md:hidden">
+        <Drawer>
+          <DrawerTrigger asChild>
+            <Button variant="ghost" size="icon" className="m-2">
+              <Menu />
+            </Button>
+          </DrawerTrigger>
+          <DrawerContent className="p-4">
+            <SidebarContent />
+          </DrawerContent>
+        </Drawer>
+      </div>
+    </>
+  );
+};
+
+export default Sidebar;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/components/*": ["components/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: process.env.BASE || '/',
+});


### PR DESCRIPTION
## Summary
- set up React + TypeScript project with Tailwind and shadcn/ui
- implement sidebar with drawer on mobile
- implement conversation list with avatars and message previews
- implement chat content area with message bubbles and input bar
- add placeholder data and basic layout
- add vite config with `process.env.BASE` support

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a21eabd88326a1d2b14ad482051a