### PR TITLE
Fix import alias resolution

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
   base: process.env.BASE || '/',
 });


### PR DESCRIPTION
## Summary
- add path alias `@` pointing to `src` to fix Vite build

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853bac2904c8326be73551d8eaa9a62