### PR TITLE
Fix base path for avatar images

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -17,7 +17,8 @@ jobs:
         with:
           node-version: 18
       - run: npm install
-      - run: BASE=/pr-${{ github.event.pull_request.number }}/ npm run build
+      # The build output is served under /elyndra.world/pr-<PR_NUMBER> on GitHub Pages
+      - run: BASE=/elyndra.world/pr-${{ github.event.pull_request.number }}/ npm run build
       - uses: actions/upload-artifact@v4
         with:
           name: dist

--- a/src/components/ChatContent.tsx
+++ b/src/components/ChatContent.tsx
@@ -5,20 +5,21 @@ import { Input } from "@/components/ui/input";
 import { Search } from 'lucide-react';
 import { ScrollArea } from "@/components/ui/scroll-area";
 
+const base = import.meta.env.BASE_URL;
 const mockMessages: Message[] = [
   {
     id: 1,
     content: 'Hi there! Welcome to the Magic Campus.',
     time: '09:00',
     sender: 'Professor Oak',
-    avatar: 'https://placekitten.com/50/50',
+    avatar: `${base}avatars/user2.png`,
   },
   {
     id: 2,
     content: 'Thank you professor!',
     time: '09:02',
     sender: 'You',
-    avatar: 'https://placekitten.com/52/52',
+    avatar: `${base}avatars/user3.png`,
     self: true,
     readBy: 3,
   },

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -15,6 +15,7 @@ export interface Conversation {
   avatar: string;
 }
 
+const base = import.meta.env.BASE_URL;
 const mockConversations: Conversation[] = [
   {
     id: 1,
@@ -22,7 +23,7 @@ const mockConversations: Conversation[] = [
     lastMessage: 'Hey everyone, meeting today at 5PM in the main hall.',
     time: '10:24',
     unread: 3,
-    avatar: 'https://placekitten.com/40/40',
+    avatar: `${base}avatars/user1.png`,
   },
   {
     id: 2,
@@ -30,7 +31,7 @@ const mockConversations: Conversation[] = [
     lastMessage: 'Please submit your assignments before Friday. Long message example to show truncation in the list.',
     time: '09:10',
     unread: 0,
-    avatar: 'https://placekitten.com/41/41',
+    avatar: `${base}avatars/user2.png`,
   },
 ];
 


### PR DESCRIPTION
## Summary
- reference avatars using `import.meta.env.BASE_URL`
- update PR preview workflow to use repository path in BASE

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build` *(fails: vite not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853bac2904c8326be73551d8eaa9a62