### PR TITLE
Add sidebar layout with simple page routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,8 @@
 import React from 'react';
-import Sidebar from '@/components/Sidebar';
-import ChatList from '@/components/ChatList';
-import ChatContent from '@/components/ChatContent';
+import MainLayout from '@/components/MainLayout';
 
 const App: React.FC = () => {
-  return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar />
-      <div className="flex flex-1 overflow-hidden">
-        <ChatList />
-        <ChatContent />
-      </div>
-    </div>
-  );
+  return <MainLayout />;
 };
 
 export default App;

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import Sidebar, { Page } from './Sidebar';
+import AboutMePage from '../pages/AboutMePage';
+import CampusAnnouncementsPage from '../pages/CampusAnnouncementsPage';
+import ChatPage from '../pages/ChatPage';
+import NewChatPage from '../pages/NewChatPage';
+import SwitchRolePage from '../pages/SwitchRolePage';
+
+const MainLayout: React.FC = () => {
+  const [active, setActive] = useState<Page>('chats');
+
+  const renderContent = () => {
+    switch (active) {
+      case 'me':
+        return <AboutMePage />;
+      case 'ann':
+        return <CampusAnnouncementsPage />;
+      case 'chats':
+        return <ChatPage />;
+      case 'new-chat':
+        return <NewChatPage />;
+      case 'switch-role':
+        return <SwitchRolePage />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar active={active} onChange={setActive} />
+      <div className="flex-1 overflow-hidden">{renderContent()}</div>
+    </div>
+  );
+};
+
+export default MainLayout;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,23 +1,39 @@
 import React from 'react';
-import { Menu, X, User, Megaphone, MessageSquare, PlusSquare, SwitchCamera } from 'lucide-react';
-import { Button } from "@/components/ui/button";
-import { Drawer, DrawerContent, DrawerTrigger } from "@/components/ui/drawer";
+import {
+  Menu,
+  User,
+  Megaphone,
+  MessageSquare,
+  PlusSquare,
+  SwitchCamera,
+  LucideIcon,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Drawer, DrawerContent, DrawerTrigger } from '@/components/ui/drawer';
 
-const items = [
-  { label: 'About Me', icon: User },
-  { label: 'Campus Announcements', icon: Megaphone },
-  { label: 'Chats', icon: MessageSquare, active: true },
-  { label: 'Create Group', icon: PlusSquare },
-  { label: 'Switch Role', icon: SwitchCamera },
+export type Page = 'me' | 'ann' | 'chats' | 'new-chat' | 'switch-role';
+
+interface SidebarProps {
+  active: Page;
+  onChange: (page: Page) => void;
+}
+
+const items: { key: Page; label: string; icon: LucideIcon }[] = [
+  { key: 'me', label: 'Me', icon: User },
+  { key: 'ann', label: 'Ann.', icon: Megaphone },
+  { key: 'chats', label: 'Chats', icon: MessageSquare },
+  { key: 'new-chat', label: 'New Chat', icon: PlusSquare },
+  { key: 'switch-role', label: 'Switch Role', icon: SwitchCamera },
 ];
 
-const SidebarContent: React.FC = () => (
+const SidebarContent: React.FC<SidebarProps> = ({ active, onChange }) => (
   <div className="flex flex-col w-56 h-full bg-gray-100 p-4 space-y-2">
     {items.map((item) => (
       <Button
-        key={item.label}
-        variant={item.active ? 'secondary' : 'ghost'}
+        key={item.key}
+        variant={item.key === active ? 'secondary' : 'ghost'}
         className="justify-start"
+        onClick={() => onChange(item.key)}
       >
         <item.icon className="mr-2 h-4 w-4" />
         {item.label}
@@ -26,26 +42,24 @@ const SidebarContent: React.FC = () => (
   </div>
 );
 
-const Sidebar: React.FC = () => {
-  return (
-    <>
-      <div className="hidden md:block h-full">
-        <SidebarContent />
-      </div>
-      <div className="md:hidden">
-        <Drawer>
-          <DrawerTrigger asChild>
-            <Button variant="ghost" size="icon" className="m-2">
-              <Menu />
-            </Button>
-          </DrawerTrigger>
-          <DrawerContent className="p-4">
-            <SidebarContent />
-          </DrawerContent>
-        </Drawer>
-      </div>
-    </>
-  );
-};
+const Sidebar: React.FC<SidebarProps> = ({ active, onChange }) => (
+  <>
+    <div className="hidden md:block h-full">
+      <SidebarContent active={active} onChange={onChange} />
+    </div>
+    <div className="md:hidden">
+      <Drawer>
+        <DrawerTrigger asChild>
+          <Button variant="ghost" size="icon" className="m-2">
+            <Menu />
+          </Button>
+        </DrawerTrigger>
+        <DrawerContent className="p-4">
+          <SidebarContent active={active} onChange={onChange} />
+        </DrawerContent>
+      </Drawer>
+    </div>
+  </>
+);
 
 export default Sidebar;

--- a/src/pages/AboutMePage.tsx
+++ b/src/pages/AboutMePage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const AboutMePage: React.FC = () => (
+  <div className="p-4">
+    <h1 className="text-2xl font-bold">About Me</h1>
+  </div>
+);
+
+export default AboutMePage;

--- a/src/pages/CampusAnnouncementsPage.tsx
+++ b/src/pages/CampusAnnouncementsPage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const CampusAnnouncementsPage: React.FC = () => (
+  <div className="p-4">
+    <h1 className="text-2xl font-bold">Campus Announcements</h1>
+  </div>
+);
+
+export default CampusAnnouncementsPage;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ChatList from '@/components/ChatList';
+import ChatContent from '@/components/ChatContent';
+
+const ChatPage: React.FC = () => (
+  <div className="flex h-full overflow-hidden">
+    <ChatList />
+    <ChatContent />
+  </div>
+);
+
+export default ChatPage;

--- a/src/pages/NewChatPage.tsx
+++ b/src/pages/NewChatPage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const NewChatPage: React.FC = () => (
+  <div className="p-4">
+    <h1 className="text-2xl font-bold">New Chat</h1>
+  </div>
+);
+
+export default NewChatPage;

--- a/src/pages/SwitchRolePage.tsx
+++ b/src/pages/SwitchRolePage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const SwitchRolePage: React.FC = () => (
+  <div className="p-4">
+    <h1 className="text-2xl font-bold">Switch Role</h1>
+  </div>
+);
+
+export default SwitchRolePage;


### PR DESCRIPTION
## Summary
- create placeholder pages for sidebar menu items
- upgrade Sidebar to accept active state and callbacks
- add new MainLayout component for sidebar navigation
- update App to use MainLayout

## Testing
- `npm test` *(fails: npm cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6853d4ddcf2883268d74588d7d32370d