### PR TITLE
Add workflow to clean up PR previews

### DIFF
--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -1,0 +1,42 @@
+name: Cleanup PR Preview
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Remove preview directory
+        run: node ./scripts/remove-preview.mjs
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add .
+            git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}"
+            git push origin gh-pages
+          else
+            echo "No preview directory to remove."
+          fi

--- a/scripts/remove-preview.mjs
+++ b/scripts/remove-preview.mjs
@@ -1,0 +1,16 @@
+import { existsSync, rmSync } from 'fs';
+import { join } from 'path';
+
+const prNumber = process.env.PR_NUMBER;
+if (!prNumber) {
+  console.error('PR_NUMBER environment variable is required');
+  process.exit(1);
+}
+
+const dir = join('.', `pr-${prNumber}`);
+if (existsSync(dir)) {
+  rmSync(dir, { recursive: true, force: true });
+  console.log(`Deleted ${dir}`);
+} else {
+  console.log(`Directory ${dir} does not exist`);
+}


### PR DESCRIPTION
## Summary
- create cleanup-pr-preview workflow that deletes `/pr-PR_NUMBER` folders when a pull request closes
- add simple Node script to remove the preview directory

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d8609b608326899494dab80ab786