### PR TITLE
Improve sidebar item layout

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {
   Menu,
+  ChevronLeft,
+  ChevronRight,
   User,
   Megaphone,
   MessageSquare,
@@ -18,6 +20,11 @@ interface SidebarProps {
   onChange: (page: Page) => void;
 }
 
+interface SidebarContentProps extends SidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
 const items: { key: Page; label: string; icon: LucideIcon }[] = [
   { key: 'me', label: 'Me', icon: User },
   { key: 'ann', label: 'Ann.', icon: Megaphone },
@@ -26,40 +33,76 @@ const items: { key: Page; label: string; icon: LucideIcon }[] = [
   { key: 'switch-role', label: 'Switch Role', icon: SwitchCamera },
 ];
 
-const SidebarContent: React.FC<SidebarProps> = ({ active, onChange }) => (
-  <div className="flex flex-col w-56 h-full bg-gray-100 p-4 space-y-2">
+const SidebarContent: React.FC<SidebarContentProps> = ({
+  active,
+  onChange,
+  collapsed,
+  onToggle,
+}) => (
+  <div
+    className={`flex flex-col ${collapsed ? 'w-16' : 'w-56'} h-full bg-gray-100 p-4 space-y-2`}
+  >
     {items.map((item) => (
       <Button
         key={item.key}
         variant={item.key === active ? 'secondary' : 'ghost'}
-        className="flex items-center justify-start w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors"
+        className="flex items-center justify-center w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors"
         onClick={() => onChange(item.key)}
       >
         <item.icon className="h-4 w-4" />
-        {item.label}
+        {!collapsed && item.label}
       </Button>
     ))}
+    <Button
+      variant="ghost"
+      className="flex items-center justify-center w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors mt-auto"
+      onClick={onToggle}
+    >
+      {collapsed ? (
+        <ChevronRight className="h-4 w-4" />
+      ) : (
+        <>
+          <ChevronLeft className="h-4 w-4" />
+          <span>Close Sidebar</span>
+        </>
+      )}
+    </Button>
   </div>
 );
 
-const Sidebar: React.FC<SidebarProps> = ({ active, onChange }) => (
-  <>
-    <div className="hidden md:block h-full">
-      <SidebarContent active={active} onChange={onChange} />
-    </div>
-    <div className="md:hidden">
-      <Drawer>
-        <DrawerTrigger asChild>
-          <Button variant="ghost" size="icon" className="m-2">
-            <Menu />
-          </Button>
-        </DrawerTrigger>
-        <DrawerContent className="p-4">
-          <SidebarContent active={active} onChange={onChange} />
-        </DrawerContent>
-      </Drawer>
-    </div>
-  </>
-);
+const Sidebar: React.FC<SidebarProps> = ({ active, onChange }) => {
+  const [collapsed, setCollapsed] = React.useState(false);
+  const toggle = () => setCollapsed((v) => !v);
+
+  return (
+    <>
+      <div className="hidden md:block h-full">
+        <SidebarContent
+          active={active}
+          onChange={onChange}
+          collapsed={collapsed}
+          onToggle={toggle}
+        />
+      </div>
+      <div className="md:hidden">
+        <Drawer>
+          <DrawerTrigger asChild>
+            <Button variant="ghost" size="icon" className="m-2">
+              <Menu />
+            </Button>
+          </DrawerTrigger>
+          <DrawerContent className="p-4">
+            <SidebarContent
+              active={active}
+              onChange={onChange}
+              collapsed={false}
+              onToggle={() => {}}
+            />
+          </DrawerContent>
+        </Drawer>
+      </div>
+    </>
+  );
+};
 
 export default Sidebar;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -50,12 +50,12 @@ const SidebarContent: React.FC<SidebarContentProps> = ({
         onClick={() => onChange(item.key)}
       >
         <item.icon className="h-4 w-4" />
-        {!collapsed && item.label}
+        {!collapsed && <span>{item.label}</span>}
       </Button>
     ))}
     <Button
       variant="ghost"
-      className="flex items-center justify-start w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors mt-auto px-2 py-2"
+      className="flex items-center justify-center w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors mt-auto px-2 py-2"
       onClick={onToggle}
     >
       {collapsed ? (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,10 +32,10 @@ const SidebarContent: React.FC<SidebarProps> = ({ active, onChange }) => (
       <Button
         key={item.key}
         variant={item.key === active ? 'secondary' : 'ghost'}
-        className="justify-start"
+        className="flex items-center justify-center w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors"
         onClick={() => onChange(item.key)}
       >
-        <item.icon className="mr-2 h-4 w-4" />
+        <item.icon className="h-4 w-4" />
         {item.label}
       </Button>
     ))}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,7 +32,7 @@ const SidebarContent: React.FC<SidebarProps> = ({ active, onChange }) => (
       <Button
         key={item.key}
         variant={item.key === active ? 'secondary' : 'ghost'}
-        className="flex items-center justify-center w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors"
+        className="flex items-center justify-start w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors"
         onClick={() => onChange(item.key)}
       >
         <item.icon className="h-4 w-4" />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -46,7 +46,7 @@ const SidebarContent: React.FC<SidebarContentProps> = ({
       <Button
         key={item.key}
         variant={item.key === active ? 'secondary' : 'ghost'}
-        className="flex items-center justify-center w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors"
+        className="flex items-center justify-start w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors px-2 py-2"
         onClick={() => onChange(item.key)}
       >
         <item.icon className="h-4 w-4" />
@@ -55,7 +55,7 @@ const SidebarContent: React.FC<SidebarContentProps> = ({
     ))}
     <Button
       variant="ghost"
-      className="flex items-center justify-center w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors mt-auto"
+      className="flex items-center justify-start w-full space-x-2 hover:bg-gray-200 rounded-md transition-colors mt-auto px-2 py-2"
       onClick={onToggle}
     >
       {collapsed ? (


### PR DESCRIPTION
## Summary
- align sidebar icons and labels in the center and add a hover highlight

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e34c08d88326bcf4a5de66dbab1b